### PR TITLE
remove set of isRDFModel to false because this feature is now deprecated in blueprints.

### DIFF
--- a/lib/pacer/blueprints/ruby_graph.rb
+++ b/lib/pacer/blueprints/ruby_graph.rb
@@ -23,7 +23,6 @@ module Pacer
 
       features.ignoresSuppliedIds = false
       features.isPersistent = false
-      features.isRDFModel = false
       features.isWrapper = false
 
       features.supportsIndices = false


### PR DESCRIPTION
isRDFModel == !supportsEdgeRetrieval AND !supportsEdgeProperties, and those features are already set later in the file.

newer blueprints graphs have begun to remove this feature, and that causes pacer to bork when it's initialized.
