### PR TITLE
Fix is and is_not vertex unwrap 

### DIFF
--- a/lib/pacer/filter/object_filter.rb
+++ b/lib/pacer/filter/object_filter.rb
@@ -32,7 +32,8 @@ module Pacer
       protected
 
       def attach_pipe(end_pipe)
-        pipe = ObjectFilterPipe.new(value, negate ? Pacer::Pipes::NOT_EQUAL : Pacer::Pipes::EQUAL)
+        obj  = if value.respond_to?(:element) then value.element else value end
+        pipe = ObjectFilterPipe.new(obj, negate ? Pacer::Pipes::NOT_EQUAL : Pacer::Pipes::EQUAL)
         pipe.set_starts end_pipe if end_pipe
         pipe
       end

--- a/spec/pacer/filter/object_filter_spec.rb
+++ b/spec/pacer/filter/object_filter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 Run.tg(:read_only) do
   use_pacer_graphml_data(:read_only)
-
+  
   describe Pacer::Filter::ObjectFilter do
     it '#is' do
       [1, 2, 3, 2, 3].to_route.is(2).to_a.should == [2, 2]
@@ -18,14 +18,14 @@ Run.tg(:read_only) do
 
     describe '#vertex filter' do
 
-      let (:filter_node) { graph.v.first }
+      let (:filter_node) { graph.vertex 3 }
     
-      it "#is" do
+      it "#is_not" do
         all_nodes = graph.v.to_a.select { |n| n.getId != filter_node.getId }
         graph.v.is_not(filter_node).to_a.should == all_nodes
       end
 
-      it "#is_not" do
+      it "#is" do
         graph.v.is(filter_node).to_a.should == [filter_node]
       end
 


### PR DESCRIPTION
Added a few spec lines for testing is and is_not operations with vertex, and added a way to unwrap every object that answer to :element in order to get a proper blueprint graph over there. Like this every non basic type, so everything coming from a Pacer wrapper will be unpack before being send to the ObjectFilterPipe.

This fix https://github.com/pangloss/pacer/issues/40

Comments, reviews and suggestions are of course accepted ;-)
- purbon
