### PR TITLE
Modifications to run with Bluprints, Pipes and Gremlin 2.4

### DIFF
--- a/lib/pacer/core/graph/edges_route.rb
+++ b/lib/pacer/core/graph/edges_route.rb
@@ -2,9 +2,9 @@ module Pacer::Core::Graph
 
   # Basic methods for routes that contain only edges.
   module EdgesRoute
-    import com.tinkerpop.gremlin.pipes.transform.OutVertexPipe
-    import com.tinkerpop.gremlin.pipes.transform.InVertexPipe
-    import com.tinkerpop.gremlin.pipes.transform.BothVerticesPipe
+    import com.tinkerpop.pipes.transform.OutVertexPipe
+    import com.tinkerpop.pipes.transform.InVertexPipe
+    import com.tinkerpop.pipes.transform.BothVerticesPipe
 
     # Extends the route with out vertices from this route's matching edges.
     #
@@ -56,7 +56,7 @@ module Pacer::Core::Graph
     #
     # @return [Core::Route]
     def labels
-      chain_route(:pipe_class => com.tinkerpop.gremlin.pipes.transform.LabelPipe,
+      chain_route(:pipe_class => com.tinkerpop.pipes.transform.LabelPipe,
                   :route_name => 'labels',
                   :element_type => :object)
     end
@@ -84,7 +84,7 @@ module Pacer::Core::Graph
     protected
 
     def id_pipe_class
-      com.tinkerpop.gremlin.pipes.transform.IdEdgePipe
+      com.tinkerpop.pipes.transform.IdEdgePipe
     end
   end
 end

--- a/lib/pacer/core/graph/vertices_route.rb
+++ b/lib/pacer/core/graph/vertices_route.rb
@@ -2,12 +2,12 @@ module Pacer::Core::Graph
 
   # Basic methods for routes that contain only vertices.
   module VerticesRoute
-    import com.tinkerpop.gremlin.pipes.transform.OutEdgesPipe
-    import com.tinkerpop.gremlin.pipes.transform.OutPipe
-    import com.tinkerpop.gremlin.pipes.transform.InEdgesPipe
-    import com.tinkerpop.gremlin.pipes.transform.InPipe
-    import com.tinkerpop.gremlin.pipes.transform.BothEdgesPipe
-    import com.tinkerpop.gremlin.pipes.transform.BothPipe
+    import com.tinkerpop.pipes.transform.OutEdgesPipe
+    import com.tinkerpop.pipes.transform.OutPipe
+    import com.tinkerpop.pipes.transform.InEdgesPipe
+    import com.tinkerpop.pipes.transform.InPipe
+    import com.tinkerpop.pipes.transform.BothEdgesPipe
+    import com.tinkerpop.pipes.transform.BothPipe
 
     # Extends the route with out edges from this route's matching vertices.
     #
@@ -219,7 +219,7 @@ module Pacer::Core::Graph
 
     # TODO: move id_pipe_class into the element_type object
     def id_pipe_class
-      com.tinkerpop.gremlin.pipes.transform.IdVertexPipe
+      com.tinkerpop.pipes.transform.IdVertexPipe
     end
   end
 end

--- a/lib/pacer/filter/collection_filter.rb
+++ b/lib/pacer/filter/collection_filter.rb
@@ -33,24 +33,24 @@ module Pacer
 
       def except=(collection)
         self.collection = collection
-        @comparison = Pacer::Pipes::NOT_EQUAL
+        @comparison = Pacer::Pipes::NOT_CONTAINED_IN
       end
 
       def except_var=(var)
         @var = var
         self.section = var
-        @comparison = Pacer::Pipes::NOT_EQUAL
+        @comparison = Pacer::Pipes::NOT_CONTAINED_IN
       end
 
       def only=(collection)
         self.collection = collection
-        @comparison = Pacer::Pipes::EQUAL
+        @comparison = Pacer::Pipes::CONTAINED_IN
       end
 
       def only_var=(var)
         @var = var
         self.section = var
-        @comparison = Pacer::Pipes::EQUAL
+        @comparison = Pacer::Pipes::CONTAINED_IN
       end
 
       protected
@@ -96,7 +96,7 @@ module Pacer
       end
 
       def inspect_class_name
-        if @comparison == Pacer::Pipes::NOT_EQUAL
+        if @comparison == Pacer::Pipes::NOT_CONTAINED_IN
           'Except'
         else
           'Only'

--- a/lib/pacer/filter/property_filter.rb
+++ b/lib/pacer/filter/property_filter.rb
@@ -69,7 +69,7 @@ module Pacer
   module Filter
     module PropertyFilter
       #import com.tinkerpop.pipes.filter.LabelCollectionFilterPipe
-      import com.tinkerpop.gremlin.pipes.filter.PropertyFilterPipe
+      import com.tinkerpop.pipes.filter.PropertyFilterPipe
 
       def filters=(f)
         if f.is_a? Filters

--- a/lib/pacer/filter/property_filter/filters.rb
+++ b/lib/pacer/filter/property_filter/filters.rb
@@ -125,7 +125,7 @@ module Pacer
             when NodeVisitor::Value
               # no op
             else
-              new_pipe = PropertyFilterPipe.new(key, value, Pacer::Pipes::EQUAL)
+              new_pipe = PropertyFilterPipe.new(key, Pacer::Pipes::EQUAL, value)
             end
             if new_pipe
               new_pipe.set_starts pipe if pipe

--- a/lib/pacer/filter/where_filter/node_visitor.rb
+++ b/lib/pacer/filter/where_filter/node_visitor.rb
@@ -9,7 +9,7 @@ module Pacer
         import com.tinkerpop.pipes.filter.AndFilterPipe
         import com.tinkerpop.pipes.filter.OrFilterPipe
         import com.tinkerpop.pipes.filter.ObjectFilterPipe
-        import com.tinkerpop.gremlin.pipes.transform.PropertyPipe
+        import com.tinkerpop.pipes.transform.PropertyPipe
         import com.tinkerpop.pipes.transform.HasCountPipe
         NeverPipe = Pacer::Pipes::NeverPipe
         IdentityPipe = Pacer::Pipes::IdentityPipe
@@ -19,21 +19,22 @@ module Pacer
         UnaryTransformPipe = Pacer::Pipes::UnaryTransformPipe
         BlockFilterPipe = Pacer::Pipes::BlockFilterPipe
 
+        import com.tinkerpop.blueprints.Compare
         Filters = {
-          '==' => FilterPipe::Filter::EQUAL,
-          '='  => FilterPipe::Filter::EQUAL,
-          '!=' => FilterPipe::Filter::NOT_EQUAL,
-          '>'  => FilterPipe::Filter::GREATER_THAN,
-          '<'  => FilterPipe::Filter::LESS_THAN,
-          '>=' => FilterPipe::Filter::GREATER_THAN_EQUAL,
-          '<=' => FilterPipe::Filter::LESS_THAN_EQUAL
+          '==' => Compare::EQUAL,
+          '='  => Compare::EQUAL,
+          '!=' => Compare::NOT_EQUAL,
+          '>'  => Compare::GREATER_THAN,
+          '<'  => Compare::LESS_THAN,
+          '>=' => Compare::GREATER_THAN_EQUAL,
+          '<=' => Compare::LESS_THAN_EQUAL
         }
 
         ReverseFilters = Filters.merge(
-          '<'  => FilterPipe::Filter::GREATER_THAN,
-          '>'  => FilterPipe::Filter::LESS_THAN,
-          '<=' => FilterPipe::Filter::GREATER_THAN_EQUAL,
-          '>=' => FilterPipe::Filter::LESS_THAN_EQUAL
+          '<'  => Compare::GREATER_THAN,
+          '>'  => Compare::LESS_THAN,
+          '<=' => Compare::GREATER_THAN_EQUAL,
+          '>=' => Compare::LESS_THAN_EQUAL
         )
 
         COMPARATORS = %w[ == != > < >= <= ]

--- a/lib/pacer/pipe/property_comparison_pipe.rb
+++ b/lib/pacer/pipe/property_comparison_pipe.rb
@@ -15,17 +15,17 @@ module Pacer::Pipes
         l = obj.getProperty(@left)
         r = obj.getProperty(@right)
         case @filter
-        when FilterPipe::Filter::EQUAL
+        when Compare::EQUAL
           return obj if l == r
-        when FilterPipe::Filter::NOT_EQUAL
+        when Compare::NOT_EQUAL
           return obj if l != r
-        when FilterPipe::Filter::GREATER_THAN
+        when Compare::GREATER_THAN
           return obj if l and r and l > r
-        when FilterPipe::Filter::LESS_THAN
+        when Compare::LESS_THAN
           return obj if l and r and l < r
-        when FilterPipe::Filter::GREATER_THAN_EQUAL
+        when Compare::GREATER_THAN_EQUAL
           return obj if l and r and l >= r
-        when FilterPipe::Filter::LESS_THAN_EQUAL
+        when Compare::LESS_THAN_EQUAL
           return obj if l and r and l <= r
         end
       end

--- a/lib/pacer/pipes.rb
+++ b/lib/pacer/pipes.rb
@@ -11,16 +11,21 @@ module Pacer
     import com.tinkerpop.pipes.filter.RangeFilterPipe
     import com.tinkerpop.pipes.filter.FilterPipe
 
-    import com.tinkerpop.gremlin.pipes.transform.IdPipe
-    import com.tinkerpop.gremlin.pipes.transform.PropertyPipe
+    import com.tinkerpop.pipes.transform.IdPipe
+    import com.tinkerpop.pipes.transform.PropertyPipe
 
     IN = com.tinkerpop.blueprints.Direction::IN
     OUT = com.tinkerpop.blueprints.Direction::OUT
     BOTH = com.tinkerpop.blueprints.Direction::BOTH
 
-    EQUAL = FilterPipe::Filter::EQUAL
-    NOT_EQUAL = FilterPipe::Filter::NOT_EQUAL
+    import com.tinkerpop.blueprints.Compare
+    EQUAL = Compare::EQUAL
+    NOT_EQUAL = Compare::NOT_EQUAL
     #GREATER_THAN, LESS_THAN, GREATER_THAN_EQUAL, LESS_THAN_EQUAL
+
+    import com.tinkerpop.blueprints.Contains
+    CONTAINED_IN = Contains::IN
+    NOT_CONTAINED_IN = Contains::NOT_IN
   end
 
   import java.util.Iterator

--- a/lib/pacer/transform/lookup_ids.rb
+++ b/lib/pacer/transform/lookup_ids.rb
@@ -16,8 +16,8 @@ module Pacer
 
   module Transform
     module LookupIds
-      import com.tinkerpop.gremlin.pipes.transform.IdVertexPipe
-      import com.tinkerpop.gremlin.pipes.transform.IdEdgePipe
+      import com.tinkerpop.pipes.transform.IdVertexPipe
+      import com.tinkerpop.pipes.transform.IdEdgePipe
 
       def attach_pipe(end_pipe)
         fail ClientError, 'Can not look up elements without the graph' unless graph

--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>pacer</artifactId>
     <!-- NOTE: the following properties are automatically updated based on the values in lib/pacer-neo4j/version.rb -->
     <properties>
-      <blueprints.version>2.3.0</blueprints.version>
+      <blueprints.version>2.4.0</blueprints.version>
       <gem.version>1.4.0</gem.version>
-      <pipes.version>2.3.0</pipes.version>
-      <gremlin.version>2.3.0</gremlin.version>
+      <pipes.version>2.4.0</pipes.version>
+      <gremlin.version>2.4.0</gremlin.version>
     </properties>
     <!-- NOTE: the following properties are automatically updated based on the values in lib/pacer-neo4j/version.rb -->
     <version>${gem.version}</version>

--- a/spec/pacer/filter/empty_filter_spec.rb
+++ b/spec/pacer/filter/empty_filter_spec.rb
@@ -21,7 +21,7 @@ Run.tg(:read_only) do
       it 'should create a pipeline with only the pipe added to it' do
         start_pipe, end_pipe = subject.send :build_pipeline
         start_pipe.should == end_pipe
-        start_pipe.should be_a Java::ComTinkerpopGremlinPipesFilter::PropertyFilterPipe
+        start_pipe.should be_a Java::ComTinkerpopPipesFilter::PropertyFilterPipe
       end
     end
   end


### PR DESCRIPTION
Apparently most changes between 2.3 and 2.4 where classes being
renamed, moved from Gremlin to Pipes and some interfaces breaking.

PropertyFilterPipe constructor changed it's signature, using the
Predicate in the middle

FilterPipe::Filter was replaced by Compare

CollectionFilter now uses Contains as predicates instead of Compare

Most tests are passing, but I still have some issue that I believe
to be some bug on the CollectionFilter due to these changes, but
I'm not familiar enough with the codebase to troubleshoot it in
a reasonable time.

I would appreciate if you could take a look and help me figure out what's wrong, only 6 specs are failing, even if you aren't planning to move to 2.4 right now.

Thanks
