### PR TITLE
Fixing a part of issue #33

### DIFF
--- a/lib/pacer/filter/property_filter/edge_filters.rb
+++ b/lib/pacer/filter/property_filter/edge_filters.rb
@@ -44,6 +44,10 @@ module Pacer
           labels.any? or super
         end
 
+        def extensions_only?
+          labels.empty? and super
+        end
+
         def to_s
           if labels.any?
             [labels.map { |l| l.to_sym.inspect }.join(', '), super].reject { |s| s == '' }.join ', '


### PR DESCRIPTION
This fix takes care of the case where `g.e(Mixin)` was ignoring the route conditions of the mixin.