### PR TITLE
Building Key Indices

### DIFF
--- a/lib/pacer/graph/pacer_graph.rb
+++ b/lib/pacer/graph/pacer_graph.rb
@@ -396,7 +396,7 @@ module Pacer
             blueprints_graph.getIndexedKeys(index_class(type)).to_set
           else
             blueprints_graph.getIndexedKeys(index_class(:vertex)).to_set +
-              blueprints_graph.getIndexedKeys(index_class(:vertex))
+              blueprints_graph.getIndexedKeys(index_class(:edge))
           end
         else
           []

--- a/lib/pacer/graph/pacer_graph.rb
+++ b/lib/pacer/graph/pacer_graph.rb
@@ -390,14 +390,10 @@ module Pacer
         end
       end
 
-      def key_indices(type = nil)
+      def key_indices(type = :vertex)
+        # will raise internal error if not one of :edge or :vertex
         if features.supportsKeyIndices
-          if type
-            blueprints_graph.getIndexedKeys(index_class(type)).to_set
-          else
-            blueprints_graph.getIndexedKeys(index_class(:vertex)).to_set +
-              blueprints_graph.getIndexedKeys(index_class(:edge))
-          end
+          blueprints_graph.getIndexedKeys(index_class(type)).to_set
         else
           []
         end


### PR DESCRIPTION
While doing some performance investigation using pacer with titan, I noticed what I think is a bug in the Key Indices module. blueprints_graph.getIndexedKeys allows query for indexed keys on edges or vertices. The Pacer key_indices method calls the getIndexedKeys twice for vertices when the type is not specified - taking the unique set of the result. This seems unnecessary at best.

I found this issue while investigating some pathologic behavior in pacer with Titan as a backend.

```
main profile results:
Total time: 115.15

     total        self    children       calls  method
----------------------------------------------------------------
    110.34        0.09      110.25      326120  Array#each
    104.25        0.00      104.25           1  TicketInserter#insert
    104.07        0.00      104.07           1  CrmKinesis::EventHandlers::Ticket#process
     65.53        0.00       65.53           6  Range#each_with_time_with_zone
     65.53        0.00       65.53           6  Range#each
     65.53        0.00       65.53           1  CrmKinesis::EventHandlers::Ticket#insert_store_day
     63.67        0.10       63.57       59710  Array#map
     61.09        0.02       61.07         433  CrmKinesis::EventHandlers::Ticket#create_vertices
     39.42        0.09       39.33       18420  Proc#call
     36.20        0.00       36.20           1  Guestly.close_graph
     36.20        0.00       36.20           1  Pacer::PacerGraph#shutdown
     36.20       36.20        0.00           1  Java::ComThinkaureliusTitanGraphdbBlueprints::TitanBlueprintsGraph#shutdown
     33.64        0.08       33.56        3038  Pacer::Core::Graph::VerticesRoute.add_edges_to
     29.34        0.06       29.27        3471  Pacer::Titan::Graph#indexed_route
     28.46        0.03       28.43        4337  Pacer::Titan::Graph#key_indices
     28.43        0.05       28.38        4337  Pacer::PacerGraph::KeyIndices.key_indices
     27.87       27.87        0.00        4337  Java::ComThinkaureliusTitanGraphdbBlueprints::TitanBlueprintsGraph#getIndexedKeys
     21.42        0.17       21.25       11143  Pacer::Core::Route.each
     20.30        0.03       20.27        3038  Pacer::Core::Graph::GraphIndexRoute.e
     15.55        0.19       15.36       55683  Java::ComTinkerpopPipes::AbstractPipe#next
     15.36        0.11       15.25       50054  Pacer::Pipes::WrappingPipe#processNextStart
     11.64        0.07       11.57        3038  Pacer::GraphTransactionsMixin.transaction
     11.17       11.04        0.13        9810  Java::ComTinkerpopPipesFilter::PropertyFilterPipe#next
     10.82        0.08       10.74        3730  Kernel.require
      9.31        0.01        9.31         433  Pacer::Core::Graph::GraphIndexRoute.v
      8.69        0.33        8.36      289956  Class#new
      8.23        0.04        8.20       30858  Kernel.tap
```

This method key_indicies is called 4337 times taking about 30% of the cpu time to build the same set over an over again. In [titan](https://github.com/thinkaurelius/titan/blob/1349a5edd1149a00da6a37a4584aed25a8164a14/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/TypeUtil.java#L76-L82) this is an expensive operation to build the set which should be done at most once per transaction.

I have a naive patch implementation we are using in testing right now to memoize this method in pacer, but I am not sure how to clear the cached values when a transaction is closed? I can extend this PR with a proposed solution for the memoizing this method or open a new PR for that work if you think it belongs here. I am curious whether this is is an issue unique to titan or if this is a slow operation across all blue prints implementations. That might help determine where the caching mechanism belongs.
